### PR TITLE
allow volume argument to be 0-255 and convert 0-128 for Ruby/SDL API.

### DIFF
--- a/lib/dxruby_sdl/sound.rb
+++ b/lib/dxruby_sdl/sound.rb
@@ -37,7 +37,10 @@ module DXRubySDL
       end
 
       def set_volume(volume, time = 0)
-        raise NotImplementedError, 'Sound#set_volume(volume, time) with MIDI'
+        if time > 0
+          raise NotImplementedError, 'Sound#set_volume(volume, time != 0)'
+        end
+        @music.set_volume_music((volume * 128 / 255).to_i)
       end
     end
     private_constant :Music
@@ -63,7 +66,7 @@ module DXRubySDL
         if time > 0
           raise NotImplementedError, 'Sound#set_volume(volume, time != 0)'
         end
-        @wave.set_volume(volume)
+        @wave.set_volume((volume * 128 / 255).to_i)
       end
     end
     private_constant :Wave

--- a/lib/dxruby_sdl/sound.rb
+++ b/lib/dxruby_sdl/sound.rb
@@ -6,6 +6,17 @@ module DXRubySDL
   class Sound
     extend Forwardable
 
+    module Common
+      MAX_DXRUBY_VOLUME = 255
+      private_constant :MAX_DXRUBY_VOLUME
+      MAX_SDL_VOLUME = 128
+      private_constant :MAX_SDL_VOLUME
+
+      def dxruby_volume_to_sdl_volume(volume)
+        (volume * MAX_SDL_VOLUME.to_f / MAX_DXRUBY_VOLUME).round
+      end
+    end
+
     @sdl_mixer_openend = false
 
     def initialize(filename)
@@ -28,6 +39,8 @@ module DXRubySDL
     private
 
     class Music
+      include Common
+
       def initialize(filename)
         @music = SDL::Mixer::Music.load(filename)
       end
@@ -40,12 +53,13 @@ module DXRubySDL
         if time > 0
           raise NotImplementedError, 'Sound#set_volume(volume, time != 0)'
         end
-        @music.set_volume_music((volume * 128 / 255).to_i)
+        @music.set_volume_music(dxruby_volume_to_sdl_volume(volume))
       end
     end
     private_constant :Music
 
     class Wave
+      include Common
       extend Forwardable
 
       def initialize(filename)
@@ -66,7 +80,7 @@ module DXRubySDL
         if time > 0
           raise NotImplementedError, 'Sound#set_volume(volume, time != 0)'
         end
-        @wave.set_volume((volume * 128 / 255).to_i)
+        @wave.set_volume(dxruby_volume_to_sdl_volume(volume))
       end
     end
     private_constant :Wave


### PR DESCRIPTION
Sound#set_volume( volume, time=0 ) を修正し、 0〜255 で指定されたボリュームを Ruby/SDL のAPIに合わせて 0〜128 に変換するようにしました。
