### PR TITLE
homebrewを使用したSDL、SGEインストール方法の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,41 @@ Current API compatibility status: http://dxruby-apis.herokuapp.com/en/
 
 (1) SDL
 
+with MacPorts.
+
 ```
-(if you use MacPorts.)
 $ sudo port install libsdl libsdl_image libsdl_mixer libsdl_sound libsdl_ttf
 ```
 
+with Homebrew
+
+	# update homebrew
+	$ brew update
+	$ brew upgrade
+	$ brew doctor
+
+	# install sdl etc.
+	$ brew install sdl
+	$ brew install sdl_image
+	$ brew install sdl_mixer
+	$ brew install sdl_ttf
+
 (2) SGE
 
+	$ curl -O http://www.digitalfanatics.org/cal/sge/files/sge030809.tar.gz
+	$ tar xvzf sge030809.tar.gz
+	$ cd sge030809
+	$ curl https://gist.github.com/steved555/963525/raw/7b638e4100f9dd1a9d00560b98ea2ddd4375b2b0/sge_030809_freetype.patch | patch
+	$ curl https://gist.github.com/steved555/963524/raw/c03396e1fb8bb87e9f4ba92597d087f730c6c48b/sge_030809_cmap.patch | patch
+	$ curl https://gist.github.com/steved555/963522/raw/5b277a0a6b08a1c077fbe2c96eead4ef1d761856/sge-030809-build.patch | patch
+	$ sed -i -e 's/-soname/-install_name/g' Makefile
+	$ make
+	$ sudo make install
+
+with Homebrew
+
 ```
-$ curl -O http://www.digitalfanatics.org/cal/sge/files/sge030809.tar.gz
-$ tar xvzf sge030809.tar.gz
-$ cd sge030809
-$ curl https://gist.github.com/steved555/963525/raw/7b638e4100f9dd1a9d00560b98ea2ddd4375b2b0/sge_030809_freetype.patch | patch
-$ curl https://gist.github.com/steved555/963524/raw/c03396e1fb8bb87e9f4ba92597d087f730c6c48b/sge_030809_cmap.patch | patch
-$ curl https://gist.github.com/steved555/963522/raw/5b277a0a6b08a1c077fbe2c96eead4ef1d761856/sge-030809-build.patch | patch
-$ sed -i -e 's/-soname/-install_name/g' Makefile
-$ make
-$ sudo make install
+$ brew install https://gist.githubusercontent.com/ymmtmdk/5b15f2b06aef5549eb5a/raw/ebf4c9758b1f772f0f6073e7b2bdbb5e9665ee74/libsge.rb
 ```
 
 (3) MS PGohic (DXRuby's default font)


### PR DESCRIPTION
Homebrewを使用した場合のSDL、SGEのインストール方法を追加した。

複数行のコード記載方法もタブによるものに変更した。
