### PR TITLE
Fix sound.

### DIFF
--- a/lib/dxruby_sdl/sound.rb
+++ b/lib/dxruby_sdl/sound.rb
@@ -88,7 +88,7 @@ module DXRubySDL
       end
 
       def stop
-        SDL::Mixer.halt(@last_played_channel)
+        SDL::Mixer.halt(@last_played_channel) if @last_played_channel
       end
     end
     private_constant :Wave

--- a/spec/lib/dxruby_sdl/sound_spec.rb
+++ b/spec/lib/dxruby_sdl/sound_spec.rb
@@ -82,6 +82,11 @@ describe DXRubySDL::Sound, '音を表すクラス' do
   end
 
   describe '#stop' do
+    it '再生していないサウンドを停止でエラーが発生しない' do
+      sound = DXRubySDL::Sound.new(fixture_path('sound.wav'))
+      expect { sound.stop }.to_not raise_error
+    end
+
     context 'WAVE file', wave: true do
       let(:path) { fixture_path('sound.wav') }
       let(:sound) { DXRubySDL::Sound.new(path) }


### PR DESCRIPTION
Soundクラスで音を鳴らしていない時にstopメソッドを呼ぶとエラーが発生しました。
DXRubyでは以下のようなコードで確認するとエラーが発生しなかったので、鳴らしていない時もstopメソッドを呼べるようにしました。

```
require 'dxruby'

sound1 = Sound.new('piano_do.wav')
sound2 = Sound.new('piano_do_2.wav')

Window.loop do
  sound1.stop
  sound2.stop
end
```
