### PR TITLE
Add Sound#loop_count=.

### DIFF
--- a/lib/dxruby_sdl/sound.rb
+++ b/lib/dxruby_sdl/sound.rb
@@ -44,15 +44,15 @@ module DXRubySDL
 
       def initialize(filename)
         @music = SDL::Mixer::Music.load(filename)
-        @loop_count = -1
+        @_loop_count = -1
       end
 
       def play
-        SDL::Mixer.play_music(@music, @loop_count)
+        SDL::Mixer.play_music(@music, @_loop_count)
       end
 
       def loop_count=(n)
-        @loop_count = n
+        @_loop_count = n
       end
 
       def set_volume(volume, time = 0)
@@ -75,11 +75,11 @@ module DXRubySDL
       def initialize(filename)
         @wave = SDL::Mixer::Wave.load(filename)
         @last_played_channel = nil
-        @loop_count = 0
+        @_loop_count = 0
       end
 
       def play
-        @last_played_channel = SDL::Mixer.play_channel(-1, @wave, @loop_count)
+        @last_played_channel = SDL::Mixer.play_channel(-1, @wave, @_loop_count)
       rescue SDL::Error => e
         if /No free channels available/ =~ e.message
           SDL::Mixer.halt(@last_played_channel == 0 ? 1 : 0)
@@ -88,7 +88,7 @@ module DXRubySDL
       end
 
       def loop_count=(n)
-        @loop_count = n
+        @_loop_count = n
       end
 
       def set_volume(volume, time = 0)

--- a/lib/dxruby_sdl/sound.rb
+++ b/lib/dxruby_sdl/sound.rb
@@ -32,8 +32,9 @@ module DXRubySDL
       end
     end
 
-    def_delegators :@sound, :play, :set_volume, :stop
+    def_delegators :@sound, :play, :loop_count=, :set_volume, :stop
 
+    alias_method :loopCount=, :loop_count=
     alias_method :setVolume, :set_volume
 
     private
@@ -43,10 +44,15 @@ module DXRubySDL
 
       def initialize(filename)
         @music = SDL::Mixer::Music.load(filename)
+        @loop_count = -1
       end
 
       def play
-        SDL::Mixer.play_music(@music, -1)
+        SDL::Mixer.play_music(@music, @loop_count)
+      end
+
+      def loop_count=(n)
+        @loop_count = n
       end
 
       def set_volume(volume, time = 0)
@@ -69,15 +75,20 @@ module DXRubySDL
       def initialize(filename)
         @wave = SDL::Mixer::Wave.load(filename)
         @last_played_channel = nil
+        @loop_count = 0
       end
 
       def play
-        @last_played_channel = SDL::Mixer.play_channel(-1, @wave, 0)
+        @last_played_channel = SDL::Mixer.play_channel(-1, @wave, @loop_count)
       rescue SDL::Error => e
         if /No free channels available/ =~ e.message
           SDL::Mixer.halt(@last_played_channel == 0 ? 1 : 0)
           retry
         end
+      end
+
+      def loop_count=(n)
+        @loop_count = n
       end
 
       def set_volume(volume, time = 0)

--- a/spec/lib/dxruby_sdl/sound_spec.rb
+++ b/spec/lib/dxruby_sdl/sound_spec.rb
@@ -84,21 +84,21 @@ describe DXRubySDL::Sound, '音を表すクラス' do
   describe '#loop_count=' do
     context 'WAVE file', wave: true do
       it 'SDL::Waveのループ回数を変更する' do
-        expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@_loop_count')).to eq(0)
+        wave =
+          sound.instance_variable_get('@sound').instance_variable_get('@wave')
+        expect(SDL::Mixer).to receive(:play_channel).with(-1, wave, 1)
         sound.loop_count = 1
-        expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@_loop_count')).to eq(1)
+        sound.play
       end
     end
 
     context 'MIDI file', midi: true do
       it 'SDL::Musicのループ回数を変更する' do
-        expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@_loop_count')).to eq(-1)
+        music =
+          sound.instance_variable_get('@sound').instance_variable_get('@music')
+        expect(SDL::Mixer).to receive(:play_music).with(music, 1)
         sound.loop_count = 1
-        expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@_loop_count')).to eq(1)
+        sound.play
       end
     end
   end

--- a/spec/lib/dxruby_sdl/sound_spec.rb
+++ b/spec/lib/dxruby_sdl/sound_spec.rb
@@ -85,20 +85,20 @@ describe DXRubySDL::Sound, '音を表すクラス' do
     context 'WAVE file', wave: true do
       it 'SDL::Waveのループ回数を変更する' do
         expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@loop_count')).to eq(0)
+                    .instance_variable_get('@_loop_count')).to eq(0)
         sound.loop_count = 1
         expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@loop_count')).to eq(1)
+                    .instance_variable_get('@_loop_count')).to eq(1)
       end
     end
 
     context 'MIDI file', midi: true do
       it 'SDL::Musicのループ回数を変更する' do
         expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@loop_count')).to eq(-1)
+                    .instance_variable_get('@_loop_count')).to eq(-1)
         sound.loop_count = 1
         expect(sound.instance_variable_get('@sound')
-                    .instance_variable_get('@loop_count')).to eq(1)
+                    .instance_variable_get('@_loop_count')).to eq(1)
       end
     end
   end

--- a/spec/lib/dxruby_sdl/sound_spec.rb
+++ b/spec/lib/dxruby_sdl/sound_spec.rb
@@ -81,6 +81,28 @@ describe DXRubySDL::Sound, '音を表すクラス' do
     end
   end
 
+  describe '#loop_count=' do
+    context 'WAVE file', wave: true do
+      it 'SDL::Waveのループ回数を変更する' do
+        expect(sound.instance_variable_get('@sound')
+                    .instance_variable_get('@loop_count')).to eq(0)
+        sound.loop_count = 1
+        expect(sound.instance_variable_get('@sound')
+                    .instance_variable_get('@loop_count')).to eq(1)
+      end
+    end
+
+    context 'MIDI file', midi: true do
+      it 'SDL::Musicのループ回数を変更する' do
+        expect(sound.instance_variable_get('@sound')
+                    .instance_variable_get('@loop_count')).to eq(-1)
+        sound.loop_count = 1
+        expect(sound.instance_variable_get('@sound')
+                    .instance_variable_get('@loop_count')).to eq(1)
+      end
+    end
+  end
+
   describe '#stop' do
     it '再生していないサウンドを停止でエラーが発生しない' do
       sound = DXRubySDL::Sound.new(fixture_path('sound.wav'))


### PR DESCRIPTION
スモウルビーの「終わるまで(  )の音を鳴らす」に当たる `play_until_done` を作成するために、音の何回鳴らすか（ループ回数）を変更できる `Sound#loop_count=` を追加しました。

DXRubyのドキュメントの http://mirichi.github.io/dxruby-doc/api/Sound_23loop_count_3D.html  を参考にして `Sound#loop_count=` の引数を `n` にしました。
あと http://dxruby.osdn.jp/DXRubyReference/20095318417765.htm に `Sound#loopCount=` の記述があったので別名で呼び出せるようにしました。

dxruby_sdlのサンプルを使用して、以下のプログラムでループ回数を変更できることを確認しました。

```
require 'dxruby'

sound = Sound.new('./sound.wav')
bgm = Sound.new('./bgm.mid')

sound.loopCount = 2
sound.play

bgm.loopCount = 0
bgm.play

Window.loop do
end
```